### PR TITLE
Basic Mime Support

### DIFF
--- a/examples/file_browser.rs
+++ b/examples/file_browser.rs
@@ -1,6 +1,6 @@
 extern crate mwf;
 
-use mwf::{View, ServerBuilder};
+use mwf::{View, ViewResult, ServerBuilder};
 use mwf::routing::{Router, RouteResolver, RouteMap};
 
 use std::path::PathBuf;
@@ -35,6 +35,71 @@ struct FileResolver
     path: Vec<String>,
 }
 
+/// Shows the page for the gived `file_path`.
+fn show_page(file_path: String) -> ViewResult
+{
+    // convert the requested file into a PathBuf
+    // if it's empty, that means we're at the current
+    // working directory
+    let file: PathBuf;
+    if file_path.is_empty() {
+        file = ".".into();
+    }
+    else {
+        file = file_path.clone().into();
+    }
+
+    // if it's a file, we'll display the contents of the file
+    if file.is_file() {
+        View::path(file_path)
+    }
+    // if it's a directory, we'll list its contents
+    else if file.is_dir() {
+        let mut contents = Vec::new();
+        for entry in file.read_dir().unwrap() {
+
+            //
+            let entry = match entry {
+                Err(_) => continue,
+                Ok(entry) => entry,
+            };
+
+            // sometimes rust is very annoying
+            // Path -> &OsStr -> OsString -> String
+            // If you know of an easier way, please file a PR and
+            // let me know, because this is absurd in my opinion
+            let entry = entry.path();
+            let entry = entry.file_name().unwrap();
+            let entry = entry.to_owned();
+            let entry = entry.into_string().unwrap();
+
+            let link = format!(
+                "<a href=\"/{0:}/{1:}\">{1:}",
+                file_path,
+                entry
+            );
+
+            contents.push(link);
+        }
+
+        // separate entries with a newline
+        let contents = contents.join("<br/>");
+
+        // wrap it with html tags
+        let contents = format!("<html>{}</html>", contents);
+
+        // mark it as a view with an html mime type
+        let mut view: View = contents.into();
+        view.mime("text/html".parse().unwrap());
+
+        Ok(view)
+    }
+    // if it's neither, idk say it's not real
+    else {
+        let msg = format!("file \"{}\" does not exist", file_path);
+        View::from(msg)
+    }
+}
 
 /// The simplest server you can make with `mwf`.
 ///
@@ -47,49 +112,7 @@ fn main()
         .router(FileRouter::new())
         // this will match any route requested by the server
         .on_page("/*", |args| {
-            let file_path = args["file"].clone();
-
-            // convert the requested file into a PathBuf
-            // if it's empty, that means we're at the current
-            // working directory
-            let file: PathBuf;
-            if file_path.is_empty() {
-                file = ".".into();
-            }
-            else {
-                file = args["file"].clone().into();
-            }
-
-            // if it's a file, we'll display the contents of the file
-            if file.is_file() {
-                View::path(file_path)
-            }
-            // if it's a directory, we'll list its contents
-            else if file.is_dir() {
-                let mut contents = Vec::new();
-                for entry in file.read_dir().unwrap() {
-                    if let Ok(entry) = entry {
-
-                        // sometimes rust is very annoying
-                        // Path -> &OsStr -> OsString -> String
-                        // If you know of an easier way, please file a PR and
-                        // let me know, because this is absurd in my opinion
-                        let entry = entry.path();
-                        let entry = entry.file_name().unwrap();
-                        let entry = entry.to_owned();
-                        let entry = entry.into_string().unwrap();
-
-                        contents.push(entry);
-                    }
-                }
-
-                View::from(contents.join("\n"))
-            }
-            // if it's neither, idk say it's not real
-            else {
-                let msg = format!("file \"{}\" does not exist", file_path);
-                View::from(msg)
-            }
+            show_page(args["file"].clone())
         })
         .start()
         .unwrap();

--- a/src/server.rs
+++ b/src/server.rs
@@ -10,7 +10,6 @@ use iron::*;
 use iron::error::HttpResult;
 use iron::status;
 use iron::Request;
-use iron::mime::*;
 use iron::headers::ContentType;
 
 ///Generates a page based on the routing information in the [RouteMap]

--- a/src/view.rs
+++ b/src/view.rs
@@ -111,6 +111,7 @@ impl From<String> for View
 mod test
 {
     use view::*;
+    use iron::mime::{Mime, TopLevel, SubLevel};
 
     #[test]
     fn from_path()
@@ -120,7 +121,16 @@ mod test
         let expected = expected.to_owned();
 
         let view = View::path(path).unwrap();
-        assert_eq!(expected, view.content);
+        let (content, mime) = view.into();
+        assert_eq!(expected, content);
+
+        // make sure the mime type matches text/plain
+        match mime {
+            Mime(TopLevel::Text, SubLevel::Plain, _) => {},
+            _ => {
+                assert!(false);
+            }
+        }
 
         assert!(View::path("src/rs.view").is_err());
     }
@@ -129,8 +139,11 @@ mod test
     fn from_string()
     {
         let input = "a";
-        let expected = input.to_owned();
-        assert_eq!(expected, View::from(input).unwrap().content);
+        let expected = input.clone();
+
+        let view = View::from(input).unwrap();
+        let (content, _) = view.into();
+        assert_eq!(expected, content);
     }
 
     #[test]
@@ -138,15 +151,27 @@ mod test
     {
         let input = "a".to_owned();
         let expected = input.clone();
-        assert_eq!(expected, View::from(input).unwrap().content);
+
+        let view = View::from(input).unwrap();
+        let (content, _) = view.into();
+        assert_eq!(expected, content);
     }
 
     #[test]
-    fn into_string()
+    fn into_tuple()
     {
         let input = "a".to_owned();
         let expected = input.clone();
-        let view: String = View::from(input).unwrap().into();
-        assert_eq!(expected, view);
+
+        let view = View::from(input).unwrap();
+        let (content, mime) = view.into();
+
+        assert_eq!(expected, content);
+        match mime {
+            Mime(TopLevel::Text, SubLevel::Plain, _) => {},
+            _ => {
+                assert!(false);
+            }
+        }
     }
 }


### PR DESCRIPTION
With this commit, any file that ends with `.html` or `.htm` (case insensitively) will automatically be assigned the mime type: `text/html`, and the mime type is embedded into the response header, which will let the browser connected to the server correctly display web pages.

This is limited only to the `View#path<T: Into<PathBuf>>(T)` function at the moment, and there is no other attempt to automatically detect mime types of files; however, the `View#mime(&mut, Mime)` method is public available, so it *can* be used to manually add it in before a page yields its response.