### PR TITLE
Reworked page handlers

### DIFF
--- a/examples/file_browser.rs
+++ b/examples/file_browser.rs
@@ -50,11 +50,20 @@ impl RequestHandler for FileBrowser
                 let entry = entry.to_owned();
                 let entry = entry.into_string().unwrap();
 
-                let link = format!(
-                    "<a href=\"/{0:}/{1:}\">{1:}",
-                    file_path,
-                    entry
-                );
+                let link: String;
+                if file_path.is_empty() {
+                    link = format!(
+                        "<a href=\"/{0:}\"> {0:} </a>",
+                        entry
+                    );
+                }
+                else {
+                    link = format!(
+                        "<a href=\"/{0:}/{1:}\"> {1:} </a>",
+                        file_path,
+                        entry
+                    );
+                }
 
                 contents.push(link);
             }

--- a/examples/file_browser.rs
+++ b/examples/file_browser.rs
@@ -1,103 +1,81 @@
 extern crate mwf;
 
-use mwf::{View, ViewResult, ServerBuilder};
-use mwf::routing::{Router, RouteResolver, RouteMap};
+use mwf::{View, ViewResult, ServerBuilder, RequestHandler};
+use mwf::routing::{Resolver, RouteMap};
 
 use std::path::PathBuf;
 
-/// Routes files to a file handler.
-///
-/// A route is composed of tokens, which are delineated by `/'.
-/// For a file router, there are the following tokens:
-/// * path literal: matches the exact part of the path
-/// * `*`: matches anything, including subdirectories and their
-///   files.
-///
-/// A route specification can be composed of any number of path
-/// literals, followed by no more than one `*`.
-///
-/// These are some examples of valid route specifications:
-/// * `/index.html`: Matches `/index.html` exactly
-/// * `/dir/index.html`: Matches `/dir/index.html` exactly
-/// * `/dir/hello*`: Matches `/dir/hello*` exactly
-/// * `/dir/*`: Matches all files and directories in `/dir/`
-/// * `/*`: Matches all files and directories on the server
-///
-/// The full path name of the file that matched will be passed
-/// to the [PageHandler] in the "file" entry of the [HashMap].
-struct FileRouter;
+/// This resolves only if the specified file in the URL exists.
+struct FileResolver;
 
-/// Resolves only paths which match the [path] specification.
-/// See [FileRouter] for a description of how the routes are
-/// matched.
-struct FileResolver
+struct FileBrowser;
+impl RequestHandler for FileBrowser
 {
-    path: Vec<String>,
-}
+    fn handle(&self, route_map: RouteMap) -> ViewResult
+    {
+        let file_path = route_map["file"].to_string();
 
-/// Shows the page for the gived `file_path`.
-fn show_page(file_path: String) -> ViewResult
-{
-    // convert the requested file into a PathBuf
-    // if it's empty, that means we're at the current
-    // working directory
-    let file: PathBuf;
-    if file_path.is_empty() {
-        file = ".".into();
-    }
-    else {
-        file = file_path.clone().into();
-    }
-
-    // if it's a file, we'll display the contents of the file
-    if file.is_file() {
-        View::path(file_path)
-    }
-    // if it's a directory, we'll list its contents
-    else if file.is_dir() {
-        let mut contents = Vec::new();
-        for entry in file.read_dir().unwrap() {
-
-            //
-            let entry = match entry {
-                Err(_) => continue,
-                Ok(entry) => entry,
-            };
-
-            // sometimes rust is very annoying
-            // Path -> &OsStr -> OsString -> String
-            // If you know of an easier way, please file a PR and
-            // let me know, because this is absurd in my opinion
-            let entry = entry.path();
-            let entry = entry.file_name().unwrap();
-            let entry = entry.to_owned();
-            let entry = entry.into_string().unwrap();
-
-            let link = format!(
-                "<a href=\"/{0:}/{1:}\">{1:}",
-                file_path,
-                entry
-            );
-
-            contents.push(link);
+        // convert the requested file into a PathBuf
+        // if it's empty, that means we're at the current
+        // working directory
+        let file: PathBuf;
+        if file_path.is_empty() {
+            file = ".".into();
+        }
+        else {
+            file = file_path.clone().into();
         }
 
-        // separate entries with a newline
-        let contents = contents.join("<br/>");
+        // if it's a file, we'll display the contents of the file
+        if file.is_file() {
+            View::path(file_path)
+        }
+        // if it's a directory, we'll list its contents
+        else if file.is_dir() {
+            let mut contents = Vec::new();
+            for entry in file.read_dir().unwrap() {
 
-        // wrap it with html tags
-        let contents = format!("<html>{}</html>", contents);
+                //
+                let entry = match entry {
+                    Err(_) => continue,
+                    Ok(entry) => entry,
+                };
 
-        // mark it as a view with an html mime type
-        let mut view: View = contents.into();
-        view.mime("text/html".parse().unwrap());
+                // sometimes rust is very annoying
+                // Path -> &OsStr -> OsString -> String
+                // If you know of an easier way, please file a PR and
+                // let me know, because this is absurd in my opinion
+                let entry = entry.path();
+                let entry = entry.file_name().unwrap();
+                let entry = entry.to_owned();
+                let entry = entry.into_string().unwrap();
 
-        Ok(view)
-    }
-    // if it's neither, idk say it's not real
-    else {
-        let msg = format!("file \"{}\" does not exist", file_path);
-        View::from(msg)
+                let link = format!(
+                    "<a href=\"/{0:}/{1:}\">{1:}",
+                    file_path,
+                    entry
+                );
+
+                contents.push(link);
+            }
+
+            // separate entries with a newline
+            let contents = contents.join("<br/>");
+
+            // wrap it with html tags
+            let contents = format!("<html>{}</html>", contents);
+
+            // mark it as a view with an html mime type
+            let mut view: View = contents.into();
+            view.mime("text/html".parse().unwrap());
+
+            Ok(view)
+        }
+        // if it's neither, idk say it's not real
+        else {
+            let msg = format!("file \"{}\" does not exist", file_path);
+            View::from(msg)
+        }
     }
 }
 
@@ -109,105 +87,42 @@ fn show_page(file_path: String) -> ViewResult
 fn main()
 {
     ServerBuilder::new()
-        .router(FileRouter::new())
-        // this will match any route requested by the server
-        .on_page("/*", |args| {
-            show_page(args["file"].clone())
-        })
+        .resolver(FileResolver::new)
+        .bind("*", FileBrowser {})
         .start()
         .unwrap();
-}
-
-impl FileRouter
-{
-    /// Creates a new FileRouter
-    ///
-    /// This is just because I prefer `FileRouter::new()` over
-    /// `FileRouter {}`.
-    fn new() -> Self
-    {
-        FileRouter {}
-    }
-}
-
-impl Router for FileRouter
-{
-    fn resolver(&self, route_spec: String) -> Box<RouteResolver>
-    {
-        // route specs are guaranteed to never have a leading or trailing /
-        let tokens: Vec<String> = route_spec.split("/")
-            .map(String::from)
-            // treat empty strings as meaning `None`, and remove them
-            .filter_map(|it| {
-                if it.is_empty() {
-                    None
-                }
-                else {
-                    Some(it)
-                }
-            })
-            .collect();
-
-        // ensure that no literals follow a star
-        {
-            let trail = tokens.iter()
-                .skip_while(|it| it.as_str() != "*")
-                .skip(1) // skip the star element
-                .next();
-
-            if let Some(it) = trail {
-                panic!("Detected trailing path literal after *: \"{}\"", it)
-            }
-        }
-
-        Box::new(FileResolver::new(tokens))
-    }
 }
 
 impl FileResolver
 {
     /// Creates a new FileResolver using the given string tokens.
-    pub fn new(tokens: Vec<String>) -> Self
+    pub fn new(_: Vec<String>) -> Box<Resolver>
     {
-        FileResolver {
-            path: tokens
-        }
+        Box::new(FileResolver {})
     }
 }
 
-impl RouteResolver for FileResolver
+impl Resolver for FileResolver
 {
     fn resolve(&self, route: &Vec<&str>) -> Option<RouteMap>
     {
+        // join it all into a single string, then check if that file exists
         let full_path = route.join("/");
-        let mut map = RouteMap::new();
-        map.insert("file".to_owned(), full_path);
-        let map = map;
-
-        for i in 0..route.len() {
-            let actual = route[i];
-
-            match self.path.get(i) {
-                None => return None,
-
-                Some(spec) => {
-                    let spec = spec.as_str();
-
-                    // if we go to this point, and we see a *, we're going
-                    // to return with the full path always
-                    if spec == "*" {
-                        return Some(map);
-                    }
-                    // if the spec literal doesn't match what we have, then
-                    // we'll reject it
-                    else if spec != actual {
-                        return None;
-                    }
-                }
-            };
+        let file: PathBuf;
+        if full_path.is_empty() {
+            file = ".".into();
+        }
+        else {
+            file = full_path.clone().into();
         }
 
-        // if we got here, then that means we matched a fully-literal path
-        Some(map)
+        if file.exists() {
+            let mut map = RouteMap::new();
+            map.insert("file".into(), full_path);
+            Some(map)
+        }
+        else {
+            None
+        }
     }
 }

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -1,6 +1,16 @@
 extern crate mwf;
 
-use mwf::{View, ServerBuilder};
+use mwf::{ServerBuilder, RequestHandler, View, ViewResult};
+use mwf::routing::RouteMap;
+
+struct HelloWorld;
+impl RequestHandler for HelloWorld
+{
+    fn handle(&self, _args: RouteMap) -> ViewResult
+    {
+        View::from("Hello, world!")
+    }
+}
 
 /// The simplest server you can make with `mwf`.
 ///
@@ -9,22 +19,8 @@ use mwf::{View, ServerBuilder};
 /// message
 fn main()
 {
-    // notice that the pages are actually returning `Result<View>`s
-    // and that From<&str> and From<String> are implemented for `View`
-    //
-    // View also has a method which takes anything which has `Into<View>`
-    // implemented, and will simply wrap it in an `Ok`, which is the
-    // actual method you are seeing invoked here
-
     ServerBuilder::new()
-        // if the root page is requested, we'll respond with hello world!
-        .on_page("/", |_| {
-            View::from("Hello, world!")
-        })
-        // if any other page is requested, say goodbye, world!
-        .on_page_not_found( |_| {
-            View::from("Goodbye, world!")
-        })
+        .bind("/", HelloWorld {})
         .start()
         .unwrap();
 }

--- a/examples/simple_portal.rs
+++ b/examples/simple_portal.rs
@@ -1,18 +1,13 @@
 extern crate mwf;
 
-use mwf::{View, ServerBuilder};
+use mwf::{View, ViewResult, RequestHandler, ServerBuilder};
 use std::sync::{Arc, Mutex};
 use std::error::Error;
 use std::fmt;
+use mwf::routing::RouteMap;
 
 #[derive(Debug)]
 struct NoSuchUserError;
-
-/// A user portal, i.e. a list of users
-struct UserPortal
-{
-    users: Vec<User>,
-}
 
 /// A user in our "system"
 struct User
@@ -26,6 +21,52 @@ struct User
     name: String,
 }
 
+struct UserPortal
+{
+    users: Arc<Mutex<Vec<User>>>,
+}
+
+impl UserPortal
+{
+    fn new(users: Vec<User>) -> Self
+    {
+        UserPortal {
+            users: Arc::new(Mutex::new(users)),
+        }
+    }
+}
+
+impl RequestHandler for UserPortal
+{
+    fn handle(&self, route_map: RouteMap) -> ViewResult
+    {
+        // grab the deets from the URL
+        let id: u32 = route_map[":id"].parse().unwrap();
+        let action = route_map[":action"].as_str();
+
+        let users = self.users.lock().unwrap();
+
+        // grab the user specified by the id
+        let user = match users.iter().find(|it| it.id == id) {
+            None => return Err(Box::new(NoSuchUserError::new())),
+            Some(x) => x,
+        };
+
+        // try to perform the given action
+        let text: String = match action {
+            "greet" => {
+                format!("Hello, {}!", user.name)
+            },
+
+            _ => {
+                "Unknown action :(".into()
+            }
+        };
+
+        View::from(text)
+    }
+}
+
 fn main()
 {
     // generate a list of user information, realistically, this would
@@ -37,120 +78,14 @@ fn main()
 
     // create a user portal using the users we made
     // we'll wrap it in an arc-mutex so that it's thread-safe
-    let portal = Arc::new(Mutex::new(UserPortal::new(users)));
-
-    // we have to make clones of portal before we start, so that the clones
-    // can each be moved safely into the closure and owned by them
-    let context1 = portal.clone();
-    let context2 = portal.clone();
-    let context3 = portal.clone();
-    let context4 = portal.clone();
+    let portal = UserPortal::new(users);
 
     ServerBuilder::new()
-        // if we're just supplied the user's id, we'll just call the view_user
-        // method on the UserPortal (everything else is just boilerplate and
-        // error handling)
-        .on_page("/user/:id/", move |args| {
-            let id: u32 = args[":id"].parse()?;
-
-            // if the text couldn't be generated, then the user
-            // with that id didn't exist
-            let text = match context1.lock().unwrap().view_user(id) {
-                None => return Err(Box::new(NoSuchUserError::new())),
-                Some(x) => x,
-            };
-
-            View::from(text)
-        })
-        // if we're asked to greet the user, we'll say hi to them
-        .on_page("/user/:id/greet", move |args| {
-            let id: u32 = args[":id"].parse()?;
-            let portal = context2.lock().unwrap();
-
-            // make sure that the user exists
-            let user = match portal.user(id) {
-                None => return Err(Box::new(NoSuchUserError::new())),
-                Some(x) => x,
-            };
-
-            let text = format!("Hello, {} (id = {})", user.name, user.id);
-
-            View::from(text)
-        })
-        // if we're supposed to edit the id of the user, we also need the
-        // new id. Then, we'll change the user's id
-        .on_page("/user/:id/edit/id/:new_id", move |args| {
-            let id: u32 = args[":id"].parse()?;
-            let new_id: u32 = args[":new_id"].parse()?;
-
-            let mut portal = context3.lock().unwrap();
-
-            // make sure that the user exists
-            let user = match portal.user_mut(id) {
-                None => return Err(Box::new(NoSuchUserError::new())),
-                Some(x) => x,
-            };
-
-            // realistically, we should check if another user has that
-            // same new_id, but oh well, this is just an example of the
-            // software, not an actual service
-            user.id = new_id;
-
-            View::from("Success!")
-        })
-        // same as above, but for the user's name
-        .on_page("/user/:id/edit/name/:new_name", move |args| {
-            let id: u32 = args[":id"].parse()?;
-            let new_name = args[":new_name"].clone();
-
-            let mut portal = context4.lock().unwrap();
-
-            // make sure that the user exists
-            let user = match portal.user_mut(id) {
-                None => return Err(Box::new(NoSuchUserError::new())),
-                Some(x) => x,
-            };
-
-            // realistically, we should check if another user has that
-            // same new_id, but oh well, this is just an example of the
-            // software, not an actual service
-            user.name = new_name;
-
-            View::from("Success!")
-        })
+        .bind("/user/:id/:action", portal)
         .start()
         .unwrap();
 }
 
-impl UserPortal
-{
-    fn new(users: Vec<User>) -> UserPortal
-    {
-        UserPortal {
-            users
-        }
-    }
-
-    fn user(&self, id: u32) -> Option<&User>
-    {
-        self.users.iter()
-            .find(|it| it.id == id)
-    }
-
-    fn user_mut(&mut self, id: u32) -> Option<&mut User>
-    {
-        self.users.iter_mut()
-            .find(|it| it.id == id)
-    }
-
-    fn view_user(&self, id: u32) -> Option<String>
-    {
-        self.user(id)
-            .and_then(|user| {
-                Some(format!("Your name is, {}", user.name))
-            })
-    }
-}
 
 impl User
 {

--- a/examples/simple_portal.rs
+++ b/examples/simple_portal.rs
@@ -60,7 +60,7 @@ impl RequestHandler for UserPortal
             },
 
             "change_id" => {
-                match arg.and_then(|it| it.parse::<u32>()) {
+                match arg.and_then(|it| it.parse::<u32>().ok()) {
                     None => {
                         "Dude, that's not a number".into()
                     },

--- a/examples/simple_portal.rs
+++ b/examples/simple_portal.rs
@@ -44,10 +44,10 @@ impl RequestHandler for UserPortal
         let id: u32 = route_map[":id"].parse().unwrap();
         let action = route_map[":action"].as_str();
 
-        let users = self.users.lock().unwrap();
+        let mut users = self.users.lock().unwrap();
 
         // grab the user specified by the id
-        let user = match users.iter().find(|it| it.id == id) {
+        let user = match users.iter_mut().find(|it| it.id == id) {
             None => return Err(Box::new(NoSuchUserError::new())),
             Some(x) => x,
         };
@@ -57,6 +57,18 @@ impl RequestHandler for UserPortal
             "greet" => {
                 format!("Hello, {}!", user.name)
             },
+
+            "change_id" => {
+                let id: u32 = route_map[":arg?"].parse().unwrap();
+                user.id = id;
+                "Success!".into()
+            },
+
+            "change_name" => {
+                let name = route_map[":arg?"].clone();
+                user.name = name;
+                "Success!".into()
+            }
 
             _ => {
                 "Unknown action :(".into()
@@ -81,7 +93,7 @@ fn main()
     let portal = UserPortal::new(users);
 
     ServerBuilder::new()
-        .bind("/user/:id/:action", portal)
+        .bind("/user/:id/:action/:arg?", portal)
         .start()
         .unwrap();
 }

--- a/examples/simple_portal.rs
+++ b/examples/simple_portal.rs
@@ -43,6 +43,7 @@ impl RequestHandler for UserPortal
         // grab the deets from the URL
         let id: u32 = route_map[":id"].parse().unwrap();
         let action = route_map[":action"].as_str();
+        let arg = route_map.get(":arg?");
 
         let mut users = self.users.lock().unwrap();
 
@@ -59,15 +60,29 @@ impl RequestHandler for UserPortal
             },
 
             "change_id" => {
-                let id: u32 = route_map[":arg?"].parse().unwrap();
-                user.id = id;
-                "Success!".into()
+                match arg.and_then(|it| it.parse::<u32>()) {
+                    None => {
+                        "Dude, that's not a number".into()
+                    },
+
+                    Some(id) => {
+                        user.id = id;
+                        "Success!".into()
+                    }
+                }
             },
 
             "change_name" => {
-                let name = route_map[":arg?"].clone();
-                user.name = name;
-                "Success!".into()
+                match arg {
+                    None => {
+                        "No name given".into()
+                    },
+
+                    Some(name) => {
+                        user.name = name.clone();
+                        "Success!".into()
+                    }
+                }
             }
 
             _ => {

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -1,0 +1,13 @@
+use routing::RouteMap;
+use view::ViewResult;
+
+/// Handles a request on the server.
+///
+/// If this handler is invoked, then you may assume that it has been correctly
+/// routed to this handler.
+pub trait RequestHandler
+    where Self: Send + Sync
+{
+    /// Handles a request whose URL tokens are given in the [route_map].
+    fn handle(&self, route_map: RouteMap) -> ViewResult;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,3 +10,7 @@ pub mod routing;
 // Export as mwf::*
 mod view;
 pub use self::view::*;
+
+// Export as mwf::*
+mod handle;
+pub use self::handle::*;

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -103,8 +103,13 @@ pub struct Router
 /// Describes the parts of a route specification in a [StandardResolver].
 enum RouteSpec
 {
+    /// A required string literal. The interior value is the string to match.
     Literal(String),
+
+    /// A required variable. The interior value is the name of the variable.
     Variable(String),
+
+    /// An optional variable. The interior value is the name of the variable.
     Optional(String),
 }
 
@@ -125,9 +130,10 @@ impl RouterBuilder
         }
     }
 
-    pub fn constructor(&mut self, resolver: Box<ResolverConstructor>)
+    /// Changes the `constructor` to use when creating new resolvers.
+    pub fn constructor(&mut self, constructor: Box<ResolverConstructor>)
     {
-        self.constructor = resolver;
+        self.constructor = constructor;
     }
 
     /// Binds a URL route to an action in the receiver object.

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -125,6 +125,11 @@ impl RouterBuilder
         }
     }
 
+    pub fn constructor(&mut self, resolver: Box<ResolverConstructor>)
+    {
+        self.constructor = resolver;
+    }
+
     /// Binds a URL route to an action in the receiver object.
     pub fn bind<T: Into<String>, H: 'static>(&mut self, path: T, handler: H)
         where H: RequestHandler

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,10 +1,8 @@
 extern crate iron;
 
 use std::sync::{Arc, RwLock};
-use std::collections::HashMap;
 
-use super::routing::*;
-use super::view::*;
+use routing::*;
 
 use iron::*;
 use iron::error::HttpResult;
@@ -12,8 +10,7 @@ use iron::status;
 use iron::Request;
 use iron::headers::ContentType;
 
-///Generates a page based on the routing information in the [RouteMap]
-pub type PageHandler = Box<Fn(RouteMap) -> ViewResult + Send + Sync>;
+use handle::RequestHandler;
 
 //
 // The framework builder
@@ -22,9 +19,7 @@ pub type PageHandler = Box<Fn(RouteMap) -> ViewResult + Send + Sync>;
 /// A builder-pattern for constructing a new [Server].
 pub struct ServerBuilder
 {
-    pages: HashMap<String, PageHandler>,
-    page_not_found: PageHandler,
-    router: Box<Router>,
+    router: RouterBuilder,
     address: String,
 }
 
@@ -37,52 +32,16 @@ impl ServerBuilder
     /// * Bound to `localhost:8080`
     pub fn new() -> Self
     {
-        let page_not_found = |_| {
-            View::from("Page Not Found")
-        };
-        let page_not_found = Box::new(page_not_found);
-
         ServerBuilder {
-            pages: HashMap::new(),
-            page_not_found,
-            router: Box::new(StandardRouter::new()),
+            router: RouterBuilder::new(),
             address: "localhost:8080".to_owned(),
         }
     }
 
-    /// Changes the [Router] instance to use to generate
-    /// [RouteResolvers] once the web server is started.
-    pub fn router<T: 'static + Router>(mut self, router: T) -> Self
+    pub fn bind<T: Into<String>, H: 'static>(mut self, path: T, handler: H) -> Self
+        where H: RequestHandler
     {
-        self.router = Box::new(router);
-        self
-    }
-
-    /// Binds a `handler` to the given route specification, `path`.
-    pub fn on_page<F: 'static + Send + Sync>(
-        mut self,
-        path: &str,
-        handler: F
-    ) -> Self
-        where F: Fn(RouteMap) -> ViewResult
-    {
-        // clean up the path first
-        // remove leading and trailing slashes (as they aren't necessary)
-        let path = path.trim_left_matches("/")
-            .trim_right_matches("/");
-
-        self.pages.insert(path.to_owned(), Box::new(handler));
-        self
-    }
-
-    /// Binds a `handler` to the 404 page.
-    pub fn on_page_not_found<F: 'static + Send + Sync>(
-        mut self,
-        handler: F
-    ) -> Self
-        where F: Fn(RouteMap) -> ViewResult
-    {
-        self.page_not_found = Box::new(handler);
+        self.router.bind(path, handler);
         self
     }
 
@@ -99,9 +58,7 @@ impl ServerBuilder
     pub fn start(self) -> HttpResult<Listening>
     {
         let framework = Server::new(
-            self.router,
-            self.pages,
-            self.page_not_found
+            self.router.into(),
         );
         let framework = RwLock::new(framework);
         let framework = Arc::new(framework);
@@ -123,92 +80,42 @@ impl ServerBuilder
 /// An instance of a running webserver.
 struct Server
 {
-    pages: Vec<(Box<RouteResolver>, PageHandler)>,
-    page_not_found: PageHandler,
+    router: Router,
 }
 
 impl Server
 {
-    /// Creates a new server, which uses `router` to generate `RouteResolvers`
-    /// for the given `pages` (which is done before the server is started),
-    /// and which will serve `page_not_found` as its 404 page.
-    fn new(
-        router: Box<Router>,
-        pages: HashMap<String, PageHandler>,
-        page_not_found: PageHandler,
-    ) -> Self
+    fn new(router: Router) -> Self
     {
-        // creates RouteResolvers for all of the route specifications
-        let pages = pages.into_iter()
-            .map(|(s, h)| {
-                (router.resolver(s), h)
-            })
-            .collect();
-
         Server {
-            pages,
-            page_not_found,
+            router
         }
     }
 
     /// Handles an incoming `request`.
     fn handle(&self, request: &mut Request) -> IronResult<Response>
     {
-        let route = request.url.path()
-            .iter()
-            .filter_map(|it| {
-                if it.is_empty() {
-                    None
-                }
-                else {
-                    Some(*it)
-                }
-            })
-            .collect();
+        let result = match self.router.handle(request) {
+            Some(x) => x,
 
-        for &(ref resolver, ref handler) in &self.pages {
-            // see if this resolver successfully matches the given route
-            let data = match resolver.resolve(&route) {
-                None => continue,
-                Some(x) => x,
-            };
-
-            // safely get the View from the handler
-            return match handler(data) {
-                Ok(view) => {
-                    let (content, mime) = view.into();
-
-                    let mut response = Response::with((status::Ok, content));
-                    response.headers.set(ContentType(mime));
-
-                    Ok(response)
-                },
-
-                Err(reason) => {
-                    let reason: String = reason.to_string();
-                    Ok(Response::with((status::InternalServerError, reason)))
-                }
+            // page not found :(
+            None => {
+                return Ok(Response::with((status::NotFound, "Oh no :(")));
             }
-        }
+        };
 
-        // couldn't find a page that would accept it
-        let mut map = HashMap::new();
-        map.insert( "path".to_owned(), route.join("/").to_owned() );
-
-        // default to the 404 page
-        let handler = &self.page_not_found;
-        match handler(map) {
+        match result {
             Ok(view) => {
                 let (content, mime) = view.into();
 
-                let mut response = Response::with((status::NotFound, content));
+                let mut response = Response::with((status::Ok, content));
                 response.headers.set(ContentType(mime));
 
                 Ok(response)
             },
 
             Err(reason) => {
-                let reason: String = reason.to_string();
+                let reason = reason.to_string();
                 Ok(Response::with((status::InternalServerError, reason)))
             }
         }

--- a/src/server.rs
+++ b/src/server.rs
@@ -38,6 +38,8 @@ impl ServerBuilder
         }
     }
 
+    /// Assigns a new `resolver` to be used in place of the current one. The
+    /// function must be a constructor which creates [Box]es of [Resolver]s.
     pub fn resolver<T: 'static>(mut self, resolver: T) -> Self
         where T: Fn(Vec<String>) -> Box<Resolver>
     {

--- a/src/server.rs
+++ b/src/server.rs
@@ -38,10 +38,22 @@ impl ServerBuilder
         }
     }
 
-    pub fn bind<T: Into<String>, H: 'static>(mut self, path: T, handler: H) -> Self
+    pub fn resolver<T: 'static>(mut self, resolver: T) -> Self
+        where T: Fn(Vec<String>) -> Box<Resolver>
+    {
+        self.router.constructor(Box::new(resolver));
+        self
+    }
+
+    /// Binds the request `handler` to a given `route` on the server.
+    pub fn bind<T: Into<String>, H: 'static>(
+        mut self,
+        route: T,
+        handler: H
+    ) -> Self
         where H: RequestHandler
     {
-        self.router.bind(path, handler);
+        self.router.bind(route, handler);
         self
     }
 


### PR DESCRIPTION
This practically redoes the entire project, but it's much nicer now.

`Router` is no longer a trait, but a struct which will try to route a requested route to the correct resolver. This is thread-safe; however, the process of building a Router is not, so a `RouterBuilder` struct handles that. In addition to the details of the Router, this structure contains a `Box` of a `Resolver`-generating function (that is, a constructor), which is the non-thread-safe part of building the resolver list.

To bind a page, you need to simply pass `ServerBuilder#bind` a structure which has the `Resolver` trait implemented. This resolver will be the resolver used to handle page bindings until another has been added.

This also implies that you can have multiple resolver instances at the same time for a server!