### PR TITLE
Add markdown support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,9 @@ name = "file_browser"
 [[example]]
 name = "simple_portal"
 
+[[example]]
+name = "markdown"
+
 [dependencies]
 iron = "0.6"
+pulldown-cmark = { version = "0.0.11", deafult-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,12 @@ name = "mwf"
 version = "0.1.0"
 authors = ["addonovan <austin@addonovan.com>"]
 
+[dependencies]
+iron = "0.6"
+pulldown-cmark = { version = "0.0.11", deafult-features = false }
+
+
+
 [[example]]
 name = "hello_world"
 
@@ -15,6 +21,5 @@ name = "simple_portal"
 [[example]]
 name = "markdown"
 
-[dependencies]
-iron = "0.6"
-pulldown-cmark = { version = "0.0.11", deafult-features = false }
+[[example]]
+name = "decorator"

--- a/examples/decorator.rs
+++ b/examples/decorator.rs
@@ -3,12 +3,19 @@ extern crate mwf;
 use mwf::{ServerBuilder, RequestHandler, ViewResult, View, ViewDecorator};
 use mwf::routing::RouteMap;
 
+/// This decorator will prepend `pre` and append `post` onto its input
+/// view's content.
 struct Decorator
 {
+    /// the string to prepend onto the front of the view's content
     pre: String,
+
+    /// the string to append onto the end of the view's content
     post: String,
 }
 
+/// A simple structure which will decorate the `markdown.md` file by
+/// using the [Decorator] struct.
 struct Markdown
 {
     decorator: Decorator,
@@ -24,6 +31,21 @@ fn main()
 
 impl Markdown
 {
+    /// Creates a new markdown struct which will use a decorate which will:
+    /// prepend:
+    /// ```html
+    /// <!DOCTYPE html>
+    /// <html>
+    /// <body>
+    /// <div>Header!</div>
+    /// ```
+    ///
+    /// and append:
+    /// ```html
+    /// <div>Footer!</div>
+    /// </body>
+    /// </html>
+    /// ```
     fn new() -> Self
     {
         Markdown {
@@ -39,6 +61,7 @@ impl RequestHandler for Markdown
 {
     fn handle(&self, _route_map: RouteMap) -> ViewResult
     {
+        // view the file, then decorate the resultant view (if it succeeded)
         View::file("examples/markdown.md")
             .and_then(|view| {
                 self.decorator.decorate(view)
@@ -50,9 +73,12 @@ impl ViewDecorator for Decorator
 {
     fn decorate(&self, view: View) -> ViewResult
     {
+        // surround the view's content with our `pre` and `post` members
         let (content, mime) = view.into();
         let content = format!("{}{}{}", self.pre, content, self.post);
 
+        // create a new view from our content, and make sure it keeps the
+        // same mime type as before!
         View::from(content).and_then(|mut view| {
             view.mime(mime);
             Ok(view)

--- a/examples/decorator.rs
+++ b/examples/decorator.rs
@@ -1,0 +1,61 @@
+extern crate mwf;
+
+use mwf::{ServerBuilder, RequestHandler, ViewResult, View, ViewDecorator};
+use mwf::routing::RouteMap;
+
+struct Decorator
+{
+    pre: String,
+    post: String,
+}
+
+struct Markdown
+{
+    decorator: Decorator,
+}
+
+fn main()
+{
+    ServerBuilder::new()
+        .bind("/", Markdown::new())
+        .start()
+        .unwrap();
+}
+
+impl Markdown
+{
+    fn new() -> Self
+    {
+        Markdown {
+            decorator: Decorator {
+                pre: "<!DOCTYPE html><html><body><div>Header!</div>".to_string(),
+                post: "<div>Footer!</div></body></html>".to_string()
+            }
+        }
+    }
+}
+
+impl RequestHandler for Markdown
+{
+    fn handle(&self, _route_map: RouteMap) -> ViewResult
+    {
+        View::file("examples/markdown.md")
+            .and_then(|view| {
+                self.decorator.decorate(view)
+            })
+    }
+}
+
+impl ViewDecorator for Decorator
+{
+    fn decorate(&self, view: View) -> ViewResult
+    {
+        let (content, mime) = view.into();
+        let content = format!("{}{}{}", self.pre, content, self.post);
+
+        View::from(content).and_then(|mut view| {
+            view.mime(mime);
+            Ok(view)
+        })
+    }
+}

--- a/examples/file_browser.rs
+++ b/examples/file_browser.rs
@@ -28,7 +28,7 @@ impl RequestHandler for FileBrowser
 
         // if it's a file, we'll display the contents of the file
         if file.is_file() {
-            View::path(file_path)
+            View::file(file_path)
         }
         // if it's a directory, we'll list its contents
         else if file.is_dir() {

--- a/examples/markdown.md
+++ b/examples/markdown.md
@@ -1,0 +1,16 @@
+# Hello world!
+
+*I* am an __example__ of a [markdown](https://google.com) file which has
+a lot of forms of formatting.
+
+<table>
+    <tr>
+        <th>This</th> <th>is</th> <th>a</th> <th>test</th>
+    </tr>
+    <tr>
+        <td>of</td> <td></td> <td>a</td> <td></td>
+    </tr>
+    <tr>
+        <td></td> <td>table</td> <td></td> <td></td>
+    </tr>
+</table>

--- a/examples/markdown.rs
+++ b/examples/markdown.rs
@@ -1,0 +1,21 @@
+extern crate mwf;
+
+use mwf::{ServerBuilder, View, ViewResult, RequestHandler};
+use mwf::routing::RouteMap;
+
+struct Markdown;
+impl RequestHandler for Markdown
+{
+    fn handle(&self, _route_map: RouteMap) -> ViewResult
+    {
+        View::file("examples/markdown.md")
+    }
+}
+
+fn main()
+{
+    ServerBuilder::new()
+        .bind("/", Markdown {})
+        .start()
+        .unwrap();
+}

--- a/examples/markdown.rs
+++ b/examples/markdown.rs
@@ -3,6 +3,8 @@ extern crate mwf;
 use mwf::{ServerBuilder, View, ViewResult, RequestHandler};
 use mwf::routing::RouteMap;
 
+/// A simple structure which will just display the `markdown.md` file in this
+/// same directory.
 struct Markdown;
 impl RequestHandler for Markdown
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 extern crate iron;
+extern crate pulldown_cmark;
 
 // Export as mwf::*
 mod server;

--- a/src/view.rs
+++ b/src/view.rs
@@ -15,9 +15,26 @@ pub type ViewResult = Result<View, Box<Error>>;
 /// which evaluates to a string.
 pub struct View
 {
+    /// the content of this view
     content: String,
+
+    /// the mime type for the file (will be inserted into the response header).
     mime: Mime,
 }
+
+/// Decorates a view with something that the view doesn't already have.
+pub trait ViewDecorator
+{
+    /// Decorates the given `view`.
+    ///
+    /// This should be called by using an `and_then` chain from
+    /// the [ViewResult].
+    fn decorate(&self, view: View) -> ViewResult;
+}
+
+//
+// Implementation
+//
 
 impl View
 {
@@ -66,6 +83,7 @@ impl View
             // convert the extension to lowercase, that way we can be case
             // insensitive when checking if it's an html file.
             let ext = ext.to_str().unwrap().to_ascii_lowercase();
+
             if ext == "html" || ext == "htm" {
                 view.mime("text/html".parse().unwrap());
             }
@@ -75,10 +93,11 @@ impl View
 
                 let original = view.content.clone();
                 let mut md = String::new();
+
                 let p = Parser::new(&original);
                 html::push_html(&mut md, p);
-                view.content = md;
 
+                view.content = md;
                 view.mime("text/html".parse().unwrap());
             }
         }


### PR DESCRIPTION
Now when `View::file` (renamed from `View::path`) detects the `.md` extension, it will hand off the source of the file to [pulldown-cmark](https://github.com/google/pulldown-cmark) to convert it to HTML, which will then be used as the content of the view.

This also added `Decorator`s, which can be applied to a `View`, usually be chaining a `.and_then` onto the `ViewResult` returned from `View::file` or `View::from`.

I made some examples demonstrating these new features:
* `examples/markdown.rs` - Very simple proof of concept on how markdown gets translated automatically
* `examples/decorator.rs` - An extension to the previous example, which will also decorate it with a footer.